### PR TITLE
Cache must be update for apt

### DIFF
--- a/tasks/requirements.yml
+++ b/tasks/requirements.yml
@@ -1,4 +1,7 @@
 ---
+- name: update apt cache
+  apt: update_cache=true cache_valid_time=600
+
 - name: install required packages (ODR-AudioEnc)
   apt:
     state: present


### PR DESCRIPTION
This fix a pb detected on the molecule test for new ubuntu focal version (20.04)